### PR TITLE
* Created notification channels for android 8+ according to different…

### DIFF
--- a/com.aware.plugin.fitbit/src/main/java/com/aware/plugin/fitbit/Plugin.java
+++ b/com.aware.plugin.fitbit/src/main/java/com/aware/plugin/fitbit/Plugin.java
@@ -165,7 +165,7 @@ public class Plugin extends Aware_Plugin {
                 fitbitAuth.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, fitbitAuth, PendingIntent.FLAG_ONE_SHOT);
 
-                NotificationCompat.Builder notBuilder = new NotificationCompat.Builder(this, Aware.AWARE_NOTIFICATION_ID);
+                NotificationCompat.Builder notBuilder = new NotificationCompat.Builder(this, Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
                 notBuilder.setSmallIcon(R.drawable.ic_stat_fitbit)
                         .setContentTitle(getString(R.string.app_name))
                         .setContentText(getString(R.string.fitbit_authenticate))
@@ -174,8 +174,10 @@ public class Plugin extends Aware_Plugin {
                         .setContentIntent(pendingIntent)
                         .setPriority(NotificationCompat.PRIORITY_HIGH);
 
+                notBuilder = Aware.setNotificationProperties(notBuilder, Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL);
+
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                    notBuilder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+                    notBuilder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
 
                 Notification notification = notBuilder.build();
                 notification.flags |= Notification.FLAG_NO_CLEAR;


### PR DESCRIPTION
… requirements:

General - Aware.NOTIFICATION_CHANNEL_GENERAL: for any generic & important notifications that require end-user interaction, or at minimum require the user to observe the notification
Data sync - Aware.NOTIFICATION_CHANNEL_DATASYNC: For uploading & download (e.g., sync study data or download/update plugins).
Silent - Aware.NOTIFICATION_CHANNEL_SILENT: For any notifications that are only required to exist in background.

* Added a global function to set notification properties according to channel importance (for v7 or older devices):
Aware.setNotificationPreference(NotificationCompat builder, int notificationImportance)
- Use Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL etc. as second variable to set importance according to the v8+ channel.

* Removed unused notification channel creation from aware-client onCreate(). All required channels are created in aware-core.

* Updated all notification functionalities to use new channels and set their properties accordingly.